### PR TITLE
Deny URL encoded requests.

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -42,24 +42,24 @@ backend dockerbackend
 frontend dockerfrontend
     bind :2375
     http-request deny unless METH_GET || { env(POST) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/auth } ! { env(AUTH) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/build } ! { env(BUILD) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/commit } ! { env(COMMIT) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/containers } ! { env(CONTAINERS) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/events } ! { env(EVENTS) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/exec } ! { env(EXEC) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/images } ! { env(IMAGES) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/info } ! { env(INFO) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/networks } ! { env(NETWORKS) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/nodes } ! { env(NODES) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/_ping } ! { env(PING) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/plugins } ! { env(PLUGINS) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/post } ! { env(POST) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/secrets } ! { env(SECRETS) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/services } ! { env(SERVICES) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/swarm } ! { env(SWARM) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/system } ! { env(SYSTEM) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/tasks } ! { env(TASKS) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/version } ! { env(VERSION) -m bool }
-    http-request deny if { path_reg ^(/v[\d\.]+)?/volumes } ! { env(VOLUMES) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } ! { env(AUTH) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } ! { env(BUILD) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/commit } ! { env(COMMIT) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers } ! { env(CONTAINERS) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/events } ! { env(EVENTS) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/exec } ! { env(EXEC) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/images } ! { env(IMAGES) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/info } ! { env(INFO) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/networks } ! { env(NETWORKS) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/nodes } ! { env(NODES) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } ! { env(PING) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/plugins } ! { env(PLUGINS) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/post } ! { env(POST) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/secrets } ! { env(SECRETS) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/services } ! { env(SERVICES) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/swarm } ! { env(SWARM) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/system } ! { env(SYSTEM) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/tasks } ! { env(TASKS) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/version } ! { env(VERSION) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/volumes } ! { env(VOLUMES) -m bool }
     default_backend dockerbackend


### PR DESCRIPTION
This change introduces support for URL encoded requests, fixes #1 . Ended up not needing to split out into ACLs and have kept the format originally used.