### PR TITLE
Add unix socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,10 @@ VOLUME /run/docker-filtered
 # Metadata
 ARG VCS_REF
 ARG BUILD_DATE
-LABEL org.label-schema.schema-version="1.0" \
+LABEL org.label-schema.schema-version="1.1" \
       org.label-schema.vendor=Tecnativa \
       org.label-schema.license=Apache-2.0 \
       org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/docker-tcp-proxy"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM haproxy:1.7-alpine
-MAINTAINER Tecnativa <info@tecnativa.com>
+LABEL maintainer="Tecnativa <info@tecnativa.com>"
 
 EXPOSE 2375
 ENV AUTH=0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM haproxy:1.7-alpine
 LABEL maintainer="Tecnativa <info@tecnativa.com>"
 
 EXPOSE 2375
+VOLUME /run/docker-filtered
 ENV AUTH=0 \
     BUILD=0 \
     COMMIT=0 \
@@ -21,9 +22,10 @@ ENV AUTH=0 \
     SYSTEM=0 \
     TASKS=0 \
     VERSION=1 \
-    VOLUMES=0
+    VOLUMES=0 \
+    SOCK_NETWORK=1 \
+    SOCK_DISK=1
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
-VOLUME /run/docker-filtered
 
 # Metadata
 ARG VCS_REF

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV AUTH=0 \
     VERSION=1 \
     VOLUMES=0
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
+VOLUME /run/docker-filtered
 
 # Metadata
 ARG VCS_REF

--- a/README.md
+++ b/README.md
@@ -46,12 +46,17 @@ requests that should never happen.
             -d --privileged \
             --name dockerproxy \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -v /run/docker-filtered:/run/docker-filtered \
             -p 127.0.0.1:2375:2375 \
             tecnativa/docker-socket-proxy
 
 2.  Connect your local docker client to that socket:
 
         $ export DOCKER_HOST=tcp://localhost
+
+or
+
+        $ export DOCKER_HOST=unix:///run/docker-filtered/docker.sock
 
 3.  You can see the docker version:
 
@@ -137,6 +142,13 @@ does not need.
 - `SYSTEM`
 - `TASKS`
 - `VOLUMES`
+
+## Grant or revoke access to API listener
+
+There are two listeners for the API and each of them can be disable the same way as the previous features:
+
+- `SOCK_NETWORK` for the port tcp/2375
+- `SOCK_DISK` for `/run/docker-filtered/docker.sock`
 
 ## Supported API versions
 

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -28,10 +28,6 @@ defaults
     load-server-state-from-file global
 
 backend dockerbackend
-    server dockersocket /var/run/docker.sock
-
-frontend dockerfrontend
-    bind :2375,/run/docker-filtered/docker.sock
     http-request deny unless METH_GET || { env(POST) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } ! { env(AUTH) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } ! { env(BUILD) -m bool }
@@ -53,4 +49,16 @@ frontend dockerfrontend
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/tasks } ! { env(TASKS) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/version } ! { env(VERSION) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/volumes } ! { env(VOLUMES) -m bool }
+
+    server dockersocket /var/run/docker.sock
+
+frontend docker-network
+    bind :2375
+    http-request deny if ! { env(SOCK_NETWORK) -m bool }
     default_backend dockerbackend
+
+frontend docker-disk
+    bind /run/docker-filtered/docker.sock
+    http-request deny if ! { env(SOCK_DISK) -m bool }
+    default_backend dockerbackend
+

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -40,7 +40,7 @@ backend dockerbackend
     server dockersocket /var/run/docker.sock
 
 frontend dockerfrontend
-    bind :2375
+    bind :2375,/run/docker-filtered/docker.sock
     http-request deny unless METH_GET || { env(POST) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } ! { env(AUTH) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } ! { env(BUILD) -m bool }

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -27,15 +27,6 @@ defaults
     # Allow seamless reloads
     load-server-state-from-file global
 
-    # Use provided example error pages
-    errorfile 400 /usr/local/etc/haproxy/errors/400.http
-    errorfile 403 /usr/local/etc/haproxy/errors/403.http
-    errorfile 408 /usr/local/etc/haproxy/errors/408.http
-    errorfile 500 /usr/local/etc/haproxy/errors/500.http
-    errorfile 502 /usr/local/etc/haproxy/errors/502.http
-    errorfile 503 /usr/local/etc/haproxy/errors/503.http
-    errorfile 504 /usr/local/etc/haproxy/errors/504.http
-
 backend dockerbackend
     server dockersocket /var/run/docker.sock
 


### PR DESCRIPTION
This app is filtering the docker.sock and making it available over the network. My change permit to have the filtering without putting in on the network: it creates an other unix-socket on the disk.

Both listeners are active by default and them use can be forbidden with the new environment variables `SOCK_NETWORK` and `SOCK_DISK`.