### PR TITLE
Privileged explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ requests that should never happen.
 
 ## Usage
 
-1.  Run the API proxy:
+1.  Run the API proxy (`--privileged` flag is required here because it connects with the docker socket, which is a privileged connection in some SELinux/AppArmor contexts and would get locked otherwise):
 
         $ docker container run \
             -d --privileged \


### PR DESCRIPTION
#7 - explained `--privileged` flag usage, because it's not clear why this flag is used here.