### PR TITLE
Improve security by inverting policy. Adding minor features.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM haproxy:1.9-alpine
 
 EXPOSE 2375
-ENV AUTH=0 \
+ENV ALLOW_RESTARTS=0 \
+    AUTH=0 \
     BUILD=0 \
     COMMIT=0 \
     CONFIGS=0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV AUTH=0 \
     POST=0 \
     SECRETS=0 \
     SERVICES=0 \
+    SESSION=0 \
     SWARM=0 \
     SYSTEM=0 \
     TASKS=0 \

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ does not need.
 - `NODES`
 - `PLUGINS`
 - `SERVICES`
+- `SESSION`
 - `SWARM`
 - `SYSTEM`
 - `TASKS`

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -42,6 +42,7 @@ backend dockerbackend
 frontend dockerfrontend
     bind :2375
     http-request deny unless METH_GET || { env(POST) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[^/]+/((stop)|(restart)|(kill)) } ! { env(ALLOW_RESTARTS) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } ! { env(AUTH) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } ! { env(BUILD) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/commit } ! { env(COMMIT) -m bool }

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -59,6 +59,7 @@ frontend dockerfrontend
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/post } ! { env(POST) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/secrets } ! { env(SECRETS) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/services } ! { env(SERVICES) -m bool }
+    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/session } ! { env(SESSION) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/swarm } ! { env(SWARM) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/system } ! { env(SYSTEM) -m bool }
     http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/tasks } ! { env(TASKS) -m bool }

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -42,28 +42,29 @@ backend dockerbackend
 frontend dockerfrontend
     bind :2375
     http-request deny unless METH_GET || { env(POST) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[^/]+/((stop)|(restart)|(kill)) } ! { env(ALLOW_RESTARTS) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } ! { env(AUTH) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } ! { env(BUILD) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/commit } ! { env(COMMIT) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/configs } ! { env(CONFIGS) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers } ! { env(CONTAINERS) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/distribution } ! { env(DISTRIBUTION) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/events } ! { env(EVENTS) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/exec } ! { env(EXEC) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/images } ! { env(IMAGES) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/info } ! { env(INFO) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/networks } ! { env(NETWORKS) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/nodes } ! { env(NODES) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } ! { env(PING) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/plugins } ! { env(PLUGINS) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/post } ! { env(POST) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/secrets } ! { env(SECRETS) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/services } ! { env(SERVICES) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/session } ! { env(SESSION) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/swarm } ! { env(SWARM) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/system } ! { env(SYSTEM) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/tasks } ! { env(TASKS) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/version } ! { env(VERSION) -m bool }
-    http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?/volumes } ! { env(VOLUMES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[^/]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } { env(AUTH) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } { env(BUILD) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/commit } { env(COMMIT) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/configs } { env(CONFIGS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers } { env(CONTAINERS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/distribution } { env(DISTRIBUTION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/events } { env(EVENTS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/exec } { env(EXEC) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/images } { env(IMAGES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/info } { env(INFO) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/networks } { env(NETWORKS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/nodes } { env(NODES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } { env(PING) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/plugins } { env(PLUGINS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/post } { env(POST) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/secrets } { env(SECRETS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/services } { env(SERVICES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/session } { env(SESSION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/swarm } { env(SWARM) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/system } { env(SYSTEM) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/tasks } { env(TASKS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/version } { env(VERSION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/volumes } { env(VOLUMES) -m bool }
+    http-request deny
     default_backend dockerbackend

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -42,7 +42,7 @@ backend dockerbackend
 frontend dockerfrontend
     bind :2375
     http-request deny unless METH_GET || { env(POST) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[^/]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } { env(AUTH) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } { env(BUILD) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/commit } { env(COMMIT) -m bool }


### PR DESCRIPTION
- If we deny all requests and only allow the API endpoints that are allowed then we are more secure if there are any new APIs coming out in the future => inverted allow/deny policy
- Added the experimental session API endpoint.
- Often some containers only need to restart/reload another container. Therefore I added a permission explicitly for that.