### PR TITLE
Add multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM haproxy:1.9-alpine
+ARG REPO=library
+FROM ${REPO}/haproxy:1.9-alpine
 
 EXPOSE 2375
 ENV ALLOW_RESTARTS=0 \

--- a/hooks/build
+++ b/hooks/build
@@ -1,7 +1,40 @@
 #!/bin/bash
 set -ex
 
+# Extract arch repo from a docker tag suffix
+REPO=""
+case "$DOCKER_TAG" in
+    *amd64)
+        REPO="library"
+        ;;
+    *arm32v5)
+        REPO="arm32v5"
+        ;;
+    *arm32v6)
+        REPO="arm32v6"
+        ;;
+    *arm32v7)
+        REPO="arm32v7"
+        ;;
+    *arm64v8)
+        REPO="arm64v8"
+        ;;
+    *i386)
+        REPO="i386"
+        ;;
+    *ppc64le)
+        REPO="ppc64le"
+        ;;
+    *s390x)
+        REPO="s390x"
+        ;;
+    *)
+        REPO="library"
+        ;;
+esac
+
 docker build \
+    --build-arg REPO="$REPO" \
     --build-arg VCS_REF="$GIT_SHA1" \
     --build-arg BUILD_DATE="$(date --rfc-3339 ns)" \
     --tag "$IMAGE_NAME" .


### PR DESCRIPTION
This adds capability for multi-arch builds on Docker Hub.

To add a build for a particular architecture, a new build should be added against the same Dockerfile, but with a tag name that ends with the architecture you wish to build for.

Eg. [`latest-arm32v6`](https://hub.docker.com/r/vividboarder/docker-socket-proxy/tags)

This will allow building branches as well if you would like to add the branch name plus architecture.

This does not build or push a new manifest, so users of a different architecture will have to specify the appropriate tag. This is the "old way" of doing this, but I am not certain we can build a manifest and push it from Docker Hub today.

Fixes #17 