### PR TITLE
Added LOG_LEVEL environment variable to set logging severity level.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV ALLOW_RESTARTS=0 \
     SYSTEM=0 \
     TASKS=0 \
     VERSION=1 \
-    VOLUMES=0
+    VOLUMES=0 \
+    LOG_LEVEL=info
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
 
 # Metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV ALLOW_RESTARTS=0 \
     EXEC=0 \
     IMAGES=0 \
     INFO=0 \
+    LOG_LEVEL=info \
     NETWORKS=0 \
     NODES=0 \
     PING=1 \
@@ -25,8 +26,7 @@ ENV ALLOW_RESTARTS=0 \
     SYSTEM=0 \
     TASKS=0 \
     VERSION=1 \
-    VOLUMES=0 \
-    LOG_LEVEL=info
+    VOLUMES=0
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
 
 # Metadata

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ does not need.
 - `TASKS`
 - `VOLUMES`
 
+## Logging
+
+You can set the logging level or severity level of the messages to be logged with the
+ environment variable `LOG_LEVEL`. Defaul value is info. Possible values are: debug, 
+ info, notice, warning, err, crit, alert and emerg.
+
 ## Supported API versions
 
 - [1.27](https://docs.docker.com/engine/api/v1.27/)

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,5 +1,5 @@
 global
-    log stdout format raw daemon
+    log stdout format raw daemon "${LOG_LEVEL}"
 
     pidfile /run/haproxy.pid
     maxconn 4000


### PR DESCRIPTION
I was having the problem that the log generates a lot of messages, consuming a lot of space. With this feature you can configure the log severity level with a environment variable.