### PR TITLE
Add manifest for multi-arch builds

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Use manifest-tool to create the manifest, given the experimental
+# "docker manifest" command isn't available yet on Docker Hub.
+
+TAG_ROOT=${DOCKER_TAG%-*}
+TARGET_ARCH=""
+case "$DOCKER_TAG" in
+    *amd64)
+        TARGET_ARCH="amd64"
+        ;;
+    *arm32v5)
+        TARGET_ARCH="arm/v5"
+        ;;
+    *arm32v6)
+        TARGET_ARCH="arm/v6"
+        ;;
+    *arm32v7)
+        TARGET_ARCH="arm/v7"
+        ;;
+    *arm64v8)
+        TARGET_ARCH="arm64/v8"
+        ;;
+    *i386)
+        TARGET_ARCH="i386"
+        ;;
+    *ppc64le)
+        TARGET_ARCH="ppc64le"
+        ;;
+    *s390x)
+        TARGET_ARCH="s390x"
+        ;;
+    *)
+        echo "Unknown target arch, skip manifest push"
+        exit 0
+        ;;
+esac
+
+# If the tag is essentially only the arch, we use latest
+if [[ "$TAG_ROOT" == "$TARGET_ARCH" ]]; then
+    TAG_ROOT="latest"
+fi
+
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Generate manifest file for this repo and tag root
+sed "s#{DOCKER_REPO}#${DOCKER_REPO%:*}#;s#{TAG_ROOT}#${TAG_ROOT}#" multi-arch-manifest-tmpl.yml > multi-arch-manifest.yml
+./manifest-tool push from-spec --ignore-missing multi-arch-manifest.yml
+
+# Fix arch for image tags
+./manifest-tool push from-args \
+    --platforms "linux/$TARGET_ARCH" \
+    --template "$DOCKER_REPO:$DOCKER_TAG" \
+    --target "$DOCKER_REPO:$DOCKER_TAG"

--- a/multi-arch-manifest-tmpl.yml
+++ b/multi-arch-manifest-tmpl.yml
@@ -1,0 +1,38 @@
+---
+image: "{DOCKER_REPO}:{TAG_ROOT}"
+manifests:
+  - image: "{DOCKER_REPO}:{TAG_ROOT}"
+    platform:
+      architecture: amd64
+      os: linux
+  - image: "{DOCKER_REPO}:{TAG_ROOT}-amd64"
+    platform:
+      architecture: amd64
+      os: linux
+  - image: "{DOCKER_REPO}:{TAG_ROOT}-arm32v6"
+    platform:
+      architecture: arm
+      os: linux
+      variant: v6
+  - image: "{DOCKER_REPO}:{TAG_ROOT}-arm32v7"
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7
+  - image: "{DOCKER_REPO}:{TAG_ROOT}-arm64v8"
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8
+  - image: "{DOCKER_REPO}:{TAG_ROOT}-i386"
+    platform:
+      architecture: i386
+      os: linux
+  - image: "{DOCKER_REPO}:{TAG_ROOT}-s390x"
+    platform:
+      architecture: s390x
+      os: linux
+  - image: "{DOCKER_REPO}:{TAG_ROOT}-ppc64le"
+    platform:
+      architecture: ppc64le
+      os: linux


### PR DESCRIPTION
Doesn't fix the arch listed on each tag, but this is a limitation
right now with the docker build. Once the `--platform` arg is no longer
experimental, we should be able to add that to make this a little cleaner

Also fix image tag platforms.

Example here: https://hub.docker.com/r/vividboarder/docker-socket-proxy/tags

This comes with it a small change to the way that the tags are formatted for mutli-arch. now it requires there to be a base tag that is followed by a suffix with the arch. Eg. rather than `arm32v7` it should be `latest-arm32v7`.

This also allows using tags or branches as well. So you can later tag `v1.0.0` and build `v1.0.0-arm32v7`, which will then be added as a manifest for the `v1.0.0` tag on Docker.