### PR TITLE
Updates HAProxy to the 2.2-alpine tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.9-alpine
+FROM haproxy:2.2-alpine
 
 EXPOSE 2375
 ENV ALLOW_RESTARTS=0 \


### PR DESCRIPTION
Updates the underlying HAProxy to the 2.2-alpine, which fixes #28 and closes #29 and closes #49.  It goes a bit less far than GH-29