### PR TITLE
Remove unused metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,3 @@ ENV ALLOW_RESTARTS=0 \
     VERSION=1 \
     VOLUMES=0
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
-
-# Metadata
-ARG VCS_REF
-ARG BUILD_DATE
-LABEL org.opencontainers.image.vendor=Tecnativa \
-      org.opencontainers.image.licenses=Apache-2.0 \
-      org.opencontainers.image.created="$BUILD_DATE" \
-      org.opencontainers.image.revision="$VCS_REF" \
-      org.opencontainers.image.source="https://github.com/Tecnativa/docker-socket-proxy"


### PR DESCRIPTION
Since #40, the correct labels are applied at build. These lines were 🗑 now.

@Tecnativa TT27819