### PR TITLE
Add a minimalistic health check to the Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ ENV ALLOW_RESTARTS=0 \
     VERSION=1 \
     VOLUMES=0
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
-HEALTHCHECK --interval=1m --timeout=10s CMD nc -z 127.0.0.1 2375 || exit 1
+HEALTHCHECK --interval=1m --timeout=10s CMD nc -z 127.0.0.1 2375

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,4 @@ ENV ALLOW_RESTARTS=0 \
     VERSION=1 \
     VOLUMES=0
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
+HEALTHCHECK --interval=1m --timeout=10s CMD nc -z 127.0.0.1 2375 || exit 1


### PR DESCRIPTION
This adds a minimalistic check to the Docker image that verifies that HAProxy is actually listening on port 2375, marking the image as unhealthy if the check fails. This, in turn, allows container orchestration tools to notify an administrator that something is wrong or even restart the container automatically if HAProxy is not listening on the specified port.

This utilizes the Busybox implementation of `netcat`, which is already included in the image itself, and thus has functionally zero impact on image size. The check interval is set for once every 60 seconds, which is reasonably normal for small services like this.

I’ve been personally using a local build of docker-socket-proxy with this modification for about six months now without any issues.

In theory, this could be made more robust by either utilizing cURL to actually validate that a proper HTTP connection can be established, or even using the Docker CLI client to check that we get a sane response from the Docker daemon that is being proxied, but both of those approaches are more invasive,would have a greater impact on runtime resource usage, and would also increase the final image size.