### PR TITLE
Add support for /grpc api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV ALLOW_RESTARTS=0 \
     DISTRIBUTION=0 \
     EVENTS=1 \
     EXEC=0 \
+    GRPC=0 \
     IMAGES=0 \
     INFO=0 \
     LOG_LEVEL=info \

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ extremely critical but can expose some information that your service does not ne
 -   `CONTAINERS`
 -   `DISTRIBUTION`
 -   `EXEC`
+-   `GRPC`
 -   `IMAGES`
 -   `INFO`
 -   `NETWORKS`

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -51,6 +51,7 @@ frontend dockerfrontend
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/distribution } { env(DISTRIBUTION) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/events } { env(EVENTS) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/exec } { env(EXEC) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/grpc } { env(GRPC) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/images } { env(IMAGES) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/info } { env(INFO) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/networks } { env(NETWORKS) -m bool }

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -34,6 +34,7 @@ def test_default_permissions(proxy_factory):
             ("info",),
             ("system", "info"),
             ("build", "."),
+            ("buildx build", "."),
             ("swarm", "init"),
         )
         _check_permissions(allowed_calls, forbidden_calls)


### PR DESCRIPTION
This makes it possible to allow calls to the `/grpc` api which is used by `docker buildx`. It is disabled by default. I could not find any documentation on what this calls actually allows and what the security implications are, so added to the "Not always needed" section in the README for now.

Fixes #60.