### PR TITLE
Add environment variable to configure Docker socket location in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV ALLOW_RESTARTS=0 \
     SECRETS=0 \
     SERVICES=0 \
     SESSION=0 \
+    SOCKET_PATH=/var/run/docker.sock \
     SWARM=0 \
     SYSTEM=0 \
     TASKS=0 \

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ extremely critical but can expose some information that your service does not ne
 -   `TASKS`
 -   `VOLUMES`
 
+## Use a different Docker socket location
+
+If your OS stores its Docker socket in a different location, you can specify this via
+the `SOCKET_PATH` environment variable.
+
+For example, [balenaOS](https://www.balena.io/os/) exposes its socket at `/var/run/balena-engine.sock`. To accommodate this, merely set the `SOCKET_PATH` environment variable to `/var/run/balena-engine.sock`.
+
 ## Development
 
 All the dependencies you need to develop this project (apart from Docker itself) are

--- a/README.md
+++ b/README.md
@@ -142,10 +142,13 @@ extremely critical but can expose some information that your service does not ne
 
 ## Use a different Docker socket location
 
-If your OS stores its Docker socket in a different location, you can specify this via
-the `SOCKET_PATH` environment variable.
+If your OS stores its Docker socket in a different location and you are unable to bind
+mount it in your container specification, you can specify this via the `SOCKET_PATH`
+environment variable.
 
-For example, [balenaOS](https://www.balena.io/os/) exposes its socket at `/var/run/balena-engine.sock`. To accommodate this, merely set the `SOCKET_PATH` environment variable to `/var/run/balena-engine.sock`.
+For example, [balenaOS](https://www.balena.io/os/) exposes its socket at
+`/var/run/balena-engine.sock`. To accommodate this, merely set the `SOCKET_PATH`
+environment variable to `/var/run/balena-engine.sock`.
 
 ## Development
 

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -37,7 +37,7 @@ defaults
     errorfile 504 /usr/local/etc/haproxy/errors/504.http
 
 backend dockerbackend
-    server dockersocket /var/run/docker.sock
+    server dockersocket $SOCKET_PATH
 
 frontend dockerfrontend
     bind :2375


### PR DESCRIPTION
This PR adds the ability to configure the location of the Docker socket within the image via an environment variable. This supports operating systems that store the socket in a non-standard location and don't allow Docker bind mounts (like [balenaOS](https://www.balena.io/os/)).

Fixes https://github.com/Tecnativa/docker-socket-proxy/issues/63