### PR TITLE
Cleanup haproxy.cfg

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,11 +1,6 @@
 global
     log stdout format raw daemon "${LOG_LEVEL}"
-
-    pidfile /run/haproxy.pid
     maxconn 4000
-
-    # Turn on stats unix socket
-    server-state-file /var/lib/haproxy/server-state
 
 defaults
     mode http
@@ -23,9 +18,6 @@ defaults
     timeout http-keep-alive 10s
     timeout check 10s
     maxconn 3000
-
-    # Allow seamless reloads
-    load-server-state-from-file global
 
     # Use provided example error pages
     errorfile 400 /usr/local/etc/haproxy/errors/400.http


### PR DESCRIPTION
* /run/haproxy.pid is not used
* seamless reload is not functional and causes a warning at startup: `[WARNING] 213/153256 (1) : Can't open server state file '/var/lib/haproxy/server-state': No such file or directory`