### PR TITLE
fix: no timeout for events route

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -39,6 +39,10 @@ defaults
 backend dockerbackend
     server dockersocket $SOCKET_PATH
 
+backend docker-events
+    server dockersocket $SOCKET_PATH
+    timeout server 0
+
 frontend dockerfrontend
     bind :2375
     http-request deny unless METH_GET || { env(POST) -m bool }
@@ -68,3 +72,5 @@ frontend dockerfrontend
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/volumes } { env(VOLUMES) -m bool }
     http-request deny
     default_backend dockerbackend
+
+    use_backend docker-events if { path,url_dec -m reg -i ^(/v[\d\.]+)?/events }


### PR DESCRIPTION
The current implementation defines a `10m` server timeout for every route exposed by the Docker API.

# Detected issue

There are some containers that need to listen for Docker events and trigger particular action when an event is received, for example [swarm-cronjob](https://github.com/crazy-max/swarm-cronjob).

The `/events` route is meant to stream forever but the timeout imposed by HAProxy is abruptly closing the connection when the timeout is reached.

# Proposed solution

With this change, HAProxy will be configured with no timeout only for the `/events` route, while preserving the existing configuration for other routes.

## Implementation details

A dedicated backend with timeout set to `0` is configured in HAProxy; this backend is used to handle only the `/events` route, which is matched using the same regular expression already used to choose whether the route is accessible or not depending on the related environment variable.