### PR TITLE
Bind to IPv4 and IPv6 in haproxy

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -44,7 +44,7 @@ backend docker-events
     timeout server 0
 
 frontend dockerfrontend
-    bind :2375
+    bind :::2375 v4v6
     http-request deny unless METH_GET || { env(POST) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/start } { env(ALLOW_START) -m bool }


### PR DESCRIPTION
Binds both IPv4 and IPv6 to allow IPv6 connectivity without affecting IPv4 only setups.

Issue: #107