### PR TITLE
Fix haproxy.cfg with regex for podman

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -46,33 +46,33 @@ backend docker-events
 frontend dockerfrontend
     bind ${BIND_CONFIG}
     http-request deny unless METH_GET || { env(POST) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/start } { env(ALLOW_START) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/stop } { env(ALLOW_STOP) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } { env(AUTH) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } { env(BUILD) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/commit } { env(COMMIT) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/configs } { env(CONFIGS) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers } { env(CONTAINERS) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/distribution } { env(DISTRIBUTION) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/events } { env(EVENTS) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/exec } { env(EXEC) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/grpc } { env(GRPC) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/images } { env(IMAGES) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/info } { env(INFO) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/networks } { env(NETWORKS) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/nodes } { env(NODES) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } { env(PING) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/plugins } { env(PLUGINS) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/secrets } { env(SECRETS) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/services } { env(SERVICES) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/session } { env(SESSION) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/swarm } { env(SWARM) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/system } { env(SYSTEM) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/tasks } { env(TASKS) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/version } { env(VERSION) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/volumes } { env(VOLUMES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/containers/[a-zA-Z0-9_.-]+/start } { env(ALLOW_START) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/containers/[a-zA-Z0-9_.-]+/stop } { env(ALLOW_STOP)
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/auth } { env(AUTH) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/build } { env(BUILD) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/commit } { env(COMMIT) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/configs } { env(CONFIGS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/containers } { env(CONTAINERS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/distribution } { env(DISTRIBUTION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/events } { env(EVENTS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/exec } { env(EXEC) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/grpc } { env(GRPC) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/images } { env(IMAGES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/info } { env(INFO) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/networks } { env(NETWORKS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/nodes } { env(NODES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/_ping } { env(PING) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/plugins } { env(PLUGINS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/secrets } { env(SECRETS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/services } { env(SERVICES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/session } { env(SESSION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/swarm } { env(SWARM) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/system } { env(SYSTEM) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/tasks } { env(TASKS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/version } { env(VERSION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/volumes } { env(VOLUMES) -m bool }
     http-request deny
     default_backend dockerbackend
 
-    use_backend docker-events if { path,url_dec -m reg -i ^(/v[\d\.]+)?/events }
+    use_backend docker-events if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/events }

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -48,7 +48,7 @@ frontend dockerfrontend
     http-request deny unless METH_GET || { env(POST) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/containers/[a-zA-Z0-9_.-]+/start } { env(ALLOW_START) -m bool }
-    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/containers/[a-zA-Z0-9_.-]+/stop } { env(ALLOW_STOP)
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/containers/[a-zA-Z0-9_.-]+/stop } { env(ALLOW_STOP) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/auth } { env(AUTH) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/build } { env(BUILD) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/\w+)?/commit } { env(COMMIT) -m bool }


### PR DESCRIPTION
podman requests start with, e.g., "/v4.6.1/libpod" which was not included in the current regex

Tested for _ping and containers, only.