### PR TITLE
chore: updated to HAproxy 3.0 and forced running as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM haproxy:2.2-alpine
+FROM haproxy:3.0-alpine
 
+USER root
 EXPOSE 2375
 ENV ALLOW_RESTARTS=0 \
     ALLOW_STOP=0 \


### PR DESCRIPTION
# Content

This MR bumps haproxy to v3.0 and force it to run as root. 

# Discussion 

Starting with haproxy 2.4, the official/upstream docker image runs with a haproxy user, instead of root ([code](https://github.com/docker-library/haproxy/blob/af88bbc9186ea2ea09fa59dc77ae9437cad687b4/Dockerfile.template#L199)).

While this is an improvement of their security posture, it's unenviable in the context of docker-socket-proxy. Indeed, haproxy needs to access the docker socket file, which is bound from the host where it belongs to `root:docker` on a default docker deployment (ie. not rootless).

My take is that docker-socket-proxy should work out of the box with the default docker configuration. And because this MR doesn't deteriorate the current security posture of this project, im submitting it as is.

# Tests

Successfully ran locally all the test I could find
- `poetry run pytest --prebuild`
- ` pre-commit run --all`