### PR TITLE
Revert "chore: updated to HAproxy 3.0 and forced running as root"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM haproxy:3.0-alpine
+FROM haproxy:2.2-alpine
 
-USER root
 EXPOSE 2375
 ENV ALLOW_RESTARTS=0 \
     ALLOW_STOP=0 \


### PR DESCRIPTION
Reverts Tecnativa/docker-socket-proxy#130

Given the issue https://github.com/Tecnativa/docker-socket-proxy/issues/132 and the lack of activity on https://github.com/haproxy/haproxy/issues/2684, let's revert this PR

@pedrobaeza @josep-tecnativa 