### PR TITLE
test: check if connection upgrades work (using exec)

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -76,3 +76,12 @@ def test_network_post_permissions(proxy_factory):
         ]
         forbidden_calls = []
         _check_permissions(allowed_calls, forbidden_calls)
+
+
+def test_exec_permissions(proxy_factory):
+    with proxy_factory(CONTAINERS=1, EXEC=1, POST=1) as container_id:
+        allowed_calls = [
+            ("exec", container_id, "ls"),
+        ]
+        forbidden_calls = []
+        _check_permissions(allowed_calls, forbidden_calls)


### PR DESCRIPTION
To prevent https://github.com/Tecnativa/docker-socket-proxy/issues/132 from happening again, this PR adds a test for `docker exec`

It passes with HAProxy 2.2 while it fails with HAProxy 3.0:

```
E               plumbum.commands.processes.ProcessExecutionError: Unexpected exit code: 1
E               Command line: | /usr/bin/docker exec 785fa7761d1fd6237322dee1c0ad2241e55817c5732ba8eeb0b6de05e66a0e05 ls
E               Stderr:       | unable to upgrade to tcp, received 200
```