### PR TITLE
Provide the ability to bind to a Unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,32 @@ For example, [balenaOS](https://www.balena.io/os/) exposes its socket at
 `/var/run/balena-engine.sock`. To accommodate this, merely set the `SOCKET_PATH`
 environment variable to `/var/run/balena-engine.sock`.
 
+## Exposing as a Unix socket
+
+If you'd like to expose the proxy as a Unix socket, you can do so by setting the
+`BIND_CONFIG` environment variable.
+
+As an example, the following command will start the proxy and bind to the socket at
+`/sockets/docker.sock`. Since this is a volume, this could then be shared with another
+container.
+
+```
+$ docker container run \
+    -d --privileged \
+    --name dockerproxy \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v docker-socket:/sockets \
+    -e BIND_CONFIG=/sockets/docker.sock \
+    tecnativa/docker-socket-proxy
+```
+
+Once running, the socket can be shared with another container by using the
+`docker-socket` volume:
+
+```
+$ docker container run -v docker-socket:/var/run ...
+```
+
 ## Development
 
 All the dependencies you need to develop this project (apart from Docker itself) are

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,21 +1,23 @@
 #!/bin/sh
 set -e
 
-# Normalize the input for DISABLE_IPV6 to lowercase
-DISABLE_IPV6_LOWER=$(echo "$DISABLE_IPV6" | tr '[:upper:]' '[:lower:]')
+if [ "${BIND_CONFIG}" = "" ]; then
+    # Normalize the input for DISABLE_IPV6 to lowercase
+    DISABLE_IPV6_LOWER=$(echo "$DISABLE_IPV6" | tr '[:upper:]' '[:lower:]')
 
-# Check for different representations of 'true' and set BIND_CONFIG
-case "$DISABLE_IPV6_LOWER" in
-    1|true|yes)
-        BIND_CONFIG=":2375"
-        ;;
-    *)
-        BIND_CONFIG="[::]:2375 v4v6"
-        ;;
-esac
+    # Check for different representations of 'true' and set BIND_CONFIG
+    case "$DISABLE_IPV6_LOWER" in
+        1|true|yes)
+            BIND_CONFIG=":2375"
+            ;;
+        *)
+            BIND_CONFIG="[::]:2375 v4v6"
+            ;;
+    esac
+fi
 
 # Process the HAProxy configuration template using sed
-sed "s/\${BIND_CONFIG}/$BIND_CONFIG/g" /usr/local/etc/haproxy/haproxy.cfg.template > /usr/local/etc/haproxy/haproxy.cfg
+sed "s#/\${BIND_CONFIG}#$BIND_CONFIG#g" /usr/local/etc/haproxy/haproxy.cfg.template > /usr/local/etc/haproxy/haproxy.cfg
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
I'm wanting to share the Docker socket with services that look for the Docker socket at `/var/run/docker.sock`. Since these apps need read-only access the proxy makes a lot of sense here. But, I'd prefer to leverage socket-based communication instead of publishing the port or relying on the container networking.

This PR provides the ability to bind the socket to a Unix socket, which can be put into a volume and shared with the other containers.