### PR TITLE
Additional timeout configuration options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,7 @@ ENV ALLOW_RESTARTS=0 \
     TIMEOUT_HTTP_REQUEST=10s \
     TIMEOUT_QUEUE=1m \
     TIMEOUT_CONNECT=10s \
-    TIMEOUT_CLIENT=50s \
-    TIMEOUT_SERVER=50s \
-    TIMEOUT_TUNNEL=3600s
-
+    TIMEOUT_CLIENT=10m \
+    TIMEOUT_SERVER=10m
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg.template

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,13 @@ ENV ALLOW_RESTARTS=0 \
     SYSTEM=0 \
     TASKS=0 \
     VERSION=1 \
-    VOLUMES=0
+    VOLUMES=0 \
+    TIMEOUT_HTTP_REQUEST=10s \
+    TIMEOUT_QUEUE=1m \
+    TIMEOUT_CONNECT=10s \
+    TIMEOUT_CLIENT=50s \
+    TIMEOUT_SERVER=50s \
+    TIMEOUT_TUNNEL=3600s
+
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg.template

--- a/README.md
+++ b/README.md
@@ -143,6 +143,30 @@ extremely critical but can expose some information that your service does not ne
 -   `TASKS`
 -   `VOLUMES`
 
+##### Timeout Configuration
+
+The Docker Socket Proxy allows configuration of various timeouts using environment variables. These timeouts control how long HAProxy waits for certain events before taking action. You can set these environment variables when running the Docker container to override the default values. Click each entry in the list to read the appropriate HAProxy Documentation.
+
+- [`TIMEOUT_HTTP_REQUEST`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20http-request): Maximum time to wait for a complete HTTP request. Default is `10s`.
+- [`TIMEOUT_QUEUE`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20queue): Maximum time a request can remain in the queue. Default is `1m`.
+- [`TIMEOUT_CONNECT`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20connect): Maximum time to wait for a connection attempt to a backend server. Default is `10s`.
+- [`TIMEOUT_CLIENT`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20client): Maximum inactivity time on the client side. Default is `50s`.
+- [`TIMEOUT_SERVER`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20server): Maximum inactivity time on the server side. Default is `50s`.
+- [`TIMEOUT_TUNNEL`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20tunnel): Maximum inactivity time for a tunnel connection. Default is `3600s` (1 hour).
+
+To set these timeouts, you can pass them as environment variables when starting the Docker container. For example:
+
+```
+docker container run \
+    -d --privileged \
+    --name dockerproxy \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -p 127.0.0.1:2375:2375 \
+    -e TIMEOUT_HTTP_REQUEST=15s \
+    -e TIMEOUT_QUEUE=2m \
+    tecnativa/docker-socket-proxy
+```
+
 ## Use a different Docker socket location
 
 If your OS stores its Docker socket in a different location and you are unable to bind

--- a/README.md
+++ b/README.md
@@ -150,9 +150,8 @@ The Docker Socket Proxy allows configuration of various timeouts using environme
 - [`TIMEOUT_HTTP_REQUEST`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20http-request): Maximum time to wait for a complete HTTP request. Default is `10s`.
 - [`TIMEOUT_QUEUE`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20queue): Maximum time a request can remain in the queue. Default is `1m`.
 - [`TIMEOUT_CONNECT`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20connect): Maximum time to wait for a connection attempt to a backend server. Default is `10s`.
-- [`TIMEOUT_CLIENT`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20client): Maximum inactivity time on the client side. Default is `50s`.
-- [`TIMEOUT_SERVER`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20server): Maximum inactivity time on the server side. Default is `50s`.
-- [`TIMEOUT_TUNNEL`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20tunnel): Maximum inactivity time for a tunnel connection. Default is `3600s` (1 hour).
+- [`TIMEOUT_CLIENT`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20client): Maximum inactivity time on the client side. Default is `10m`.
+- [`TIMEOUT_SERVER`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20server): Maximum inactivity time on the server side. Default is `10m`.
 
 To set these timeouts, you can pass them as environment variables when starting the Docker container. For example:
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,19 +15,26 @@ case "$DISABLE_IPV6_LOWER" in
 esac
 
 # Process the HAProxy configuration template using sed
-sed "s/\${BIND_CONFIG}/$BIND_CONFIG/g" /usr/local/etc/haproxy/haproxy.cfg.template > /usr/local/etc/haproxy/haproxy.cfg
+sed -e "s|\${BIND_CONFIG}|$BIND_CONFIG|g" \
+    -e "s|\${TIMEOUT_HTTP_REQUEST}|$TIMEOUT_HTTP_REQUEST|g" \
+    -e "s|\${TIMEOUT_QUEUE}|$TIMEOUT_QUEUE|g" \
+    -e "s|\${TIMEOUT_CONNECT}|$TIMEOUT_CONNECT|g" \
+    -e "s|\${TIMEOUT_CLIENT}|$TIMEOUT_CLIENT|g" \
+    -e "s|\${TIMEOUT_SERVER}|$TIMEOUT_SERVER|g" \
+    -e "s|\${TIMEOUT_TUNNEL}|$TIMEOUT_TUNNEL|g" \
+    /usr/local/etc/haproxy/haproxy.cfg.template > /usr/local/etc/haproxy/haproxy.cfg
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
-	set -- haproxy "$@"
+    set -- haproxy "$@"
 fi
 
 if [ "$1" = 'haproxy' ]; then
-	shift # "haproxy"
-	# if the user wants "haproxy", let's add a couple useful flags
-	#   -W  -- "master-worker mode" (similar to the old "haproxy-systemd-wrapper"; allows for reload via "SIGUSR2")
-	#   -db -- disables background mode
-	set -- haproxy -W -db "$@"
+    shift # "haproxy"
+    # if the user wants "haproxy", let's add a couple useful flags
+    #   -W  -- "master-worker mode" (similar to the old "haproxy-systemd-wrapper"; allows for reload via "SIGUSR2")
+    #   -db -- disables background mode
+    set -- haproxy -W -db "$@"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,7 +21,6 @@ sed -e "s|\${BIND_CONFIG}|$BIND_CONFIG|g" \
     -e "s|\${TIMEOUT_CONNECT}|$TIMEOUT_CONNECT|g" \
     -e "s|\${TIMEOUT_CLIENT}|$TIMEOUT_CLIENT|g" \
     -e "s|\${TIMEOUT_SERVER}|$TIMEOUT_SERVER|g" \
-    -e "s|\${TIMEOUT_TUNNEL}|$TIMEOUT_TUNNEL|g" \
     /usr/local/etc/haproxy/haproxy.cfg.template > /usr/local/etc/haproxy/haproxy.cfg
 
 # first arg is `-f` or `--some-option`

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -20,7 +20,6 @@ defaults
     timeout connect ${TIMEOUT_CONNECT}
     timeout client ${TIMEOUT_CLIENT}
     timeout server ${TIMEOUT_SERVER}
-    timeout tunnel ${TIMEOUT_TUNNEL}
     timeout http-keep-alive 10s
     timeout check 10s
     maxconn 3000

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -18,8 +18,9 @@ defaults
     timeout http-request 10s
     timeout queue 1m
     timeout connect 10s
-    timeout client 10m
-    timeout server 10m
+    timeout client 2d
+    timeout server 2d
+    timeout tunnel 2d
     timeout http-keep-alive 10s
     timeout check 10s
     maxconn 3000

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -15,12 +15,12 @@ defaults
     option http-server-close
     option redispatch
     retries 3
-    timeout http-request 10s
-    timeout queue 1m
-    timeout connect 10s
-    timeout client 2d
-    timeout server 2d
-    timeout tunnel 2d
+    timeout http-request ${TIMEOUT_HTTP_REQUEST}
+    timeout queue ${TIMEOUT_QUEUE}
+    timeout connect ${TIMEOUT_CONNECT}
+    timeout client ${TIMEOUT_CLIENT}
+    timeout server ${TIMEOUT_SERVER}
+    timeout tunnel ${TIMEOUT_TUNNEL}
     timeout http-keep-alive 10s
     timeout check 10s
     maxconn 3000


### PR DESCRIPTION
Hello,

I find this proxy to be a really useful tool, however I've found that for my use case, certain operations are liable to timeouts. 

As far as I can tell, these timeout defaults cannot easily be modified using the current version's config.

I've added options to allow flexible HAProxy timeouts, and sensible defaults (the HAProxy defaults as inferred from the documentation).
I've updated the Readme to account for the additions, along with links to the relevant pages in the HAProxy documentation.

All tests pass for Python 3.11.4.

Thank you.