### PR TITLE
Upgrade HAProxy image tag to lts-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.2-alpine
+FROM haproxy:lts-alpine
 
 EXPOSE 2375
 ENV ALLOW_RESTARTS=0 \
@@ -32,4 +32,4 @@ ENV ALLOW_RESTARTS=0 \
     VERSION=1 \
     VOLUMES=0
 COPY docker-entrypoint.sh /usr/local/bin/
-COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg.template
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/README.md
+++ b/README.md
@@ -37,16 +37,19 @@ never happen.
 
 ## Usage
 
-1.  Run the API proxy (`--privileged` flag is required here because it connects with the
-    docker socket, which is a privileged connection in some SELinux/AppArmor contexts
-    and would get locked otherwise):
+1.  Run the API proxy:
 
         $ docker container run \
-            -d --privileged \
+            -d \
+            --group-add "$(getent group docker | cut -d: -f3)" \
             --name dockerproxy \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -p 127.0.0.1:2375:2375 \
             tecnativa/docker-socket-proxy
+
+    The `--group-add` adds the container's user (`haproxy`) to the `docker` group, allowing access to the Docker socket. This assumes that the `docker` group exists and has access to the Docker socket.
+    
+    An additional `--privileged` flag is required in some SELinux/AppArmor contexts, because the Docker socket is considered a privileged resource and might otherwise be blocked.
 
 2.  Connect your local docker client to that socket:
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,18 +4,17 @@ set -e
 # Normalize the input for DISABLE_IPV6 to lowercase
 DISABLE_IPV6_LOWER=$(echo "$DISABLE_IPV6" | tr '[:upper:]' '[:lower:]')
 
-# Check for different representations of 'true' and set BIND_CONFIG
+# Check for different representations of 'true' and set BIND_PORT and BIND_OPTIONS accordingly
 case "$DISABLE_IPV6_LOWER" in
     1|true|yes)
-        BIND_CONFIG=":2375"
+        export BIND_PORT=':2375'
+        export BIND_OPTIONS=''
         ;;
     *)
-        BIND_CONFIG="[::]:2375 v4v6"
+        export BIND_PORT=':::2375'
+        export BIND_OPTIONS='v4v6'
         ;;
 esac
-
-# Process the HAProxy configuration template using sed
-sed "s/\${BIND_CONFIG}/$BIND_CONFIG/g" /usr/local/etc/haproxy/haproxy.cfg.template > /usr/local/etc/haproxy/haproxy.cfg
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,7 +1,7 @@
 global
     log stdout format raw daemon "${LOG_LEVEL}"
 
-    pidfile /run/haproxy.pid
+    pidfile /tmp/haproxy.pid
     maxconn 4000
 
     # Turn on stats unix socket
@@ -44,7 +44,7 @@ backend docker-events
     timeout server 0
 
 frontend dockerfrontend
-    bind ${BIND_CONFIG}
+    bind "$BIND_PORT" "$BIND_OPTIONS"
     http-request deny unless METH_GET || { env(POST) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/start } { env(ALLOW_START) -m bool }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "docker-socket-proxy"
 version = "0.0.0"
 description = ""
 authors = ["Tecnativa"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+import grp
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -56,6 +57,7 @@ def proxy_factory(image):
     @contextmanager
     def _proxy(**env_vars):
         container_id = None
+        docker_gid = grp.getgrnam("docker").gr_gid
         env_list = [f"--env={key}={value}" for key, value in env_vars.items()]
         _logger.info(f"Starting {image} container with: {env_list}")
         try:
@@ -66,6 +68,7 @@ def proxy_factory(image):
                 "--privileged",
                 "--publish=2375",
                 "--volume=/var/run/docker.sock:/var/run/docker.sock",
+                f"--group-add={docker_gid}",
                 *env_list,
                 image,
             ).strip()


### PR DESCRIPTION
This PR includes the following changes:

- set Poetry to not run in package-mode
- upgraded base image tag from haproxy:2.2-alpine to haproxy:lts-alpine
- resolved permission issues cause by user in base image changing from root to haproxy
- updated tests
- updated documentation

WARNING!
This PR will change how the image is used. An additional parameter `--group-add=<docker_group_gid>` is required to give the container's user (`haproxy`) permissions to access the Docker socket.