### PR TITLE
[ADD] v1.51 version to README.md and Modernice CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   build-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python:
@@ -47,7 +47,7 @@ jobs:
           echo "CACHE=${{ secrets.CACHE_DATE }} ${{ runner.os }} $(python -VV |
           sha256sum | cut -d' ' -f1) ${{ hashFiles('pyproject.toml') }} ${{
           hashFiles('poetry.lock') }}" >> $GITHUB_ENV
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             .cache.~
@@ -61,7 +61,7 @@ jobs:
       # Run tests
       - run: poetry run pytest --prebuild
   build-push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       registry:
         image: registry:2
@@ -73,24 +73,24 @@ jobs:
       PUSH: ${{ toJSON(github.event_name != 'pull_request') }}
     steps:
       # Set up Docker Environment
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             /tmp/.buildx-cache
           key: buildx|${{ secrets.CACHE_DATE }}|${{ runner.os }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
           install: true
       # Build and push
       - name: Docker meta for local images
         id: docker_meta_local
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: crazy-max/ghaction-docker-meta@v4
         with:
           images: localhost:5000/${{ env.DOCKER_IMAGE_NAME }}
           tag-edge: true
@@ -99,7 +99,7 @@ jobs:
             {{major}}
             {{major}}.{{minor}}
       - name: Build and push to local (test) registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile
@@ -121,13 +121,13 @@ jobs:
       # Next jobs only happen outside of pull requests and on main branches
       - name: Login to DockerHub
         if: ${{ fromJSON(env.PUSH) }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_LOGIN }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         if: ${{ fromJSON(env.PUSH) }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ secrets.BOT_LOGIN }}
@@ -135,7 +135,7 @@ jobs:
       - name: Docker meta for public images
         if: ${{ fromJSON(env.PUSH) }}
         id: docker_meta_public
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: crazy-max/ghaction-docker-meta@v4
         with:
           images: |
             ghcr.io/${{ env.DOCKER_IMAGE_NAME }}
@@ -147,7 +147,7 @@ jobs:
             {{major}}.{{minor}}
       - name: Build and push to public registry(s)
         if: ${{ fromJSON(env.PUSH) }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+      - uses: pre-commit/action@v3.0.1

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ info, notice, warning, err, crit, alert and emerg.
 -   [1.29](https://docs.docker.com/engine/api/v1.29/)
 -   [1.30](https://docs.docker.com/engine/api/v1.30/)
 -   [1.37](https://docs.docker.com/engine/api/v1.37/)
+-   [1.51](https://docs.docker.com/engine/api/v1.51/)
 
 ## Image tags
 


### PR DESCRIPTION
The proxy already accepts `v1.51` endpoints.  
This PR updates the README to list Docker Engine API 1.51 as supported, and modernices CI