### PR TITLE
Updated the underlying haproxy version from 2.2 to 3.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.2-alpine
+FROM haproxy:3.2.4-alpine
 
 EXPOSE 2375
 ENV ALLOW_RESTARTS=0 \
@@ -33,3 +33,5 @@ ENV ALLOW_RESTARTS=0 \
     VOLUMES=0
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg.template
+USER root
+CMD ["haproxy", "-f", "/tmp/haproxy.cfg"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,7 +15,7 @@ case "$DISABLE_IPV6_LOWER" in
 esac
 
 # Process the HAProxy configuration template using sed
-sed "s/\${BIND_CONFIG}/$BIND_CONFIG/g" /usr/local/etc/haproxy/haproxy.cfg.template > /usr/local/etc/haproxy/haproxy.cfg
+sed "s/\${BIND_CONFIG}/$BIND_CONFIG/g" /usr/local/etc/haproxy/haproxy.cfg.template > /tmp/haproxy.cfg
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -46,6 +46,8 @@ backend docker-events
 frontend dockerfrontend
     bind ${BIND_CONFIG}
     http-request deny unless METH_GET || { env(POST) -m bool }
+
+    # Allowed endpoints
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/start } { env(ALLOW_START) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/stop } { env(ALLOW_STOP) -m bool }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [tool.poetry]
 name = "docker-socket-proxy"
-version = "0.0.0"
+version = "1.0.0"
 description = ""
 authors = ["Tecnativa"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
# Changes Incorporated:

1. Upgraded haproxy version to 3.2.4 from 2.2
2. Since haproxy now runs as `haproxy` user [line #102](https://github.com/docker-library/haproxy/blob/master/3.3/Dockerfile), I placed `haproxy.cfg` file, inside /tmp. That makes no security tampering from USER side from inside of our Dockerfile.
3. Changed the docker-socket-proxy version from `0.0.0` to `1.0.0`, since we upgraded the haproxy to a major version.

Happy to contribute.