### PR TITLE
[FIX] Raise default nofile limit for HAProxy v3

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Raise default nofile limit for HAProxy v3
+ulimit -n 10000 2>/dev/null || true
+
 # Normalize the input for DISABLE_IPV6 to lowercase
 DISABLE_IPV6_LOWER=$(echo "$DISABLE_IPV6" | tr '[:upper:]' '[:lower:]')
 


### PR DESCRIPTION
HAProxy v3 can fail to start with the default file descriptor limit (1024).  
This change raises it to 10000 by default so containers work out-of-the-box.  

This fixes by default https://github.com/Tecnativa/docker-socket-proxy/issues/160
