### PR TITLE
Add touch command to create /var/lib/haproxy/server-state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,6 @@ ENV ALLOW_RESTARTS=0 \
     VOLUMES=0
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg.template
+RUN touch /var/lib/haproxy/server-state
 USER root
 CMD ["haproxy", "-f", "/tmp/haproxy.cfg"]


### PR DESCRIPTION
This partially addresses issue #123.

The following warning appears in docker-service-proxy service logs after HAProxy was updated:

[WARNING] 257/231940 (1) : Can't open global server state file '/var/lib/haproxy/server-state': No such file or directory

Adding this touch command to the Dockerfile will create the server-state file in the Docker image and silence this warning.