### PR TITLE
Update haproxy.cfg to silence warning about 0 for server timeout

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -41,7 +41,7 @@ backend dockerbackend
 
 backend docker-events
     server dockersocket $SOCKET_PATH
-    timeout server 0
+    timeout server 30s
 
 frontend dockerfrontend
     bind ${BIND_CONFIG}


### PR DESCRIPTION
This PR partially addresses issue #123 by changing the configured value of the server timeout for the docker-events backend from 0 to 30s. It silences the following warning message:

[WARNING] While not properly invalid, you will certainly encounter various problems with such a configuration. To fix this, please ensure that all following timeouts are set to a non-zero value: 'client', 'connect', 'server'.