### PR TITLE
Allow to override BIND_CONFIG from environment

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,21 +4,23 @@ set -e
 # Raise default nofile limit for HAProxy v3
 ulimit -n 10000 2>/dev/null || true
 
-# Normalize the input for DISABLE_IPV6 to lowercase
-DISABLE_IPV6_LOWER=$(echo "$DISABLE_IPV6" | tr '[:upper:]' '[:lower:]')
+if [ -z "$BIND_CONFIG" ]; then
+	# Normalize the input for DISABLE_IPV6 to lowercase
+	DISABLE_IPV6_LOWER=$(echo "$DISABLE_IPV6" | tr '[:upper:]' '[:lower:]')
 
-# Check for different representations of 'true' and set BIND_CONFIG
-case "$DISABLE_IPV6_LOWER" in
-    1|true|yes)
-        BIND_CONFIG=":2375"
-        ;;
-    *)
-        BIND_CONFIG="[::]:2375 v4v6"
-        ;;
-esac
+	# Check for different representations of 'true' and set BIND_CONFIG
+	case "$DISABLE_IPV6_LOWER" in
+	    1|true|yes)
+		BIND_CONFIG=":2375"
+		;;
+	    *)
+		BIND_CONFIG="[::]:2375 v4v6"
+		;;
+	esac
+fi
 
 # Process the HAProxy configuration template using sed
-sed "s/\${BIND_CONFIG}/$BIND_CONFIG/g" /usr/local/etc/haproxy/haproxy.cfg.template > /tmp/haproxy.cfg
+sed "s|\${BIND_CONFIG}|$BIND_CONFIG|g" /usr/local/etc/haproxy/haproxy.cfg.template > /tmp/haproxy.cfg
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
This allows to listen on a Unix socket, for example. It was tested with "BIND_CONFIG=/shared/podman.sock mode 660" and verifying that the socket was created with expected permissions.

Replaced sed field separators to avoid conflicts with Unix paths.

Resolves #69