### PR TITLE
[IMP] Update base HAProxy version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:3.2.4-alpine
+FROM haproxy:3.4.2-alpine
 
 EXPOSE 2375
 ENV ALLOW_RESTARTS=0 \


### PR DESCRIPTION
Updates HAProxy to the latest LTS version according to https://www.haproxy.org/
Fixes https://github.com/Tecnativa/docker-socket-proxy/issues/178
Please review @roninatx @pedrobaeza 
@Tecnativa 